### PR TITLE
Adjust to ci updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,5 +63,5 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.pypi_password }}
-          skip_existing: true
+          skip-existing: true
           verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
         types_or: [yaml, markdown, html, css, javascript, json]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.254
+    rev: v0.0.256
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ ignore = [
     "PLR2004", # Magic values
     "PLR0913", # Too many arguments
 ]
-target-version = "py39"
 
 # Exclude a variety of commonly ignored directories.
 exclude = [


### PR DESCRIPTION
- Updated ruff and removed `target-version`
- Adapted to new style for [gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)